### PR TITLE
Remove submodules, since CMake FetchContent is used; Fix build on MacOS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "external/reaper-sdk"]
-	path = external/reaper-sdk
-	url = https://github.com/justinfrankel/reaper-sdk
-[submodule "external/WDL"]
-	path = external/WDL
-	url = https://github.com/justinfrankel/WDL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,12 +102,6 @@ if(WIN32)
     ${PROJECT_NAME}
       PRIVATE
       /W3 /WX)
-else()
-  target_compile_options(
-    ${PROJECT_NAME}
-      PRIVATE
-      -Wall -Wextra -Wpedantic
-  )
 endif()
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# path for external 3rd party library dependencies 
+# path for external 3rd party library dependencies
 include(FetchContent)
 set(PROJECT_LIB_DIR ${PROJECT_SOURCE_DIR}/lib)
 
@@ -49,7 +49,7 @@ if(DEFINED ENV{VCPKG_DEFAULT_TRIPLET} AND NOT DEFINED VCPKG_TARGET_TRIPLET)
   set(VCPKG_TARGET_TRIPLET "$ENV{VCPKG_DEFAULT_TRIPLET}" CACHE STRING "")
 endif()
 
-FILE(GLOB header_paths 
+FILE(GLOB header_paths
     ${PROJECT_LIB_DIR}/*/include
     ${PROJECT_LIB_DIR}/*/sdk
     )
@@ -99,14 +99,14 @@ set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 23)
 if(WIN32)
   add_compile_definitions(NOMINMAX _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE)
   target_compile_options(
-    ${PROJECT_NAME} 
-      PRIVATE 
+    ${PROJECT_NAME}
+      PRIVATE
       /W3 /WX)
 else()
   target_compile_options(
     ${PROJECT_NAME}
       PRIVATE
-      -Wall -Wextra -Werror -Wpedantic 
+      -Wall -Wextra -Wpedantic
   )
 endif()
 

--- a/src/configvar.h
+++ b/src/configvar.h
@@ -26,6 +26,9 @@ furnished to / do so, subject to the following conditions:
 ******************************************************************************/
 
 #pragma once
+#ifndef _WIN32
+    #include<wdltypes.h>
+#endif
 #include <reaper_plugin_functions.h>
 
 namespace reasolotus

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,9 @@
 #include <unordered_map>
 #include <vector>
 #define REAPERAPI_IMPLEMENT
+#ifndef _WIN32
+    #include<wdltypes.h>
+#endif
 #include <reaper_plugin_functions.h>
 
 #include "configvar.h"


### PR DESCRIPTION
- Removed git submodules for consistency, since `FetchContent` is used to get external dependencies
- Removed `-Werror` to fix `/Users/matthias/reasolotus/lib/WDL/WDL/wdltypes.h:261:85: warning: unused parameter 'format' [-Wunused-parameter]` - WDL seems to not care about warnings: https://github.com/justinfrankel/WDL/commit/255d37def10f67baba0faadf284a0b860e9c8256
- included `wdltypes.h` to avoid `/Users/matthias/reasolotus/lib/reaper-sdk/sdk/reaper_plugin_functions.h:182:99: error: unknown type name 'WDL_INT64'` - I am not sure if this is the correct approach to fix this.
- Auto-trimmed some whitespace